### PR TITLE
Fix GitHub OAuth redirect: derive callback URL from request origin

### DIFF
--- a/src/app/api/github/auth/__tests__/oauth-redirect.test.ts
+++ b/src/app/api/github/auth/__tests__/oauth-redirect.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests that the GitHub OAuth redirect_uri is derived from the incoming
+ * request origin rather than from NEXT_PUBLIC_APP_URL, preventing the
+ * callback from pointing at localhost in production. (Fixes #4)
+ */
+
+// Polyfill Request for jsdom environment (only url is needed by the route)
+if (typeof globalThis.Request === 'undefined') {
+  (globalThis as any).Request = class Request {
+    url: string;
+    constructor(url: string) { this.url = url; }
+  };
+}
+
+// Mock jose to avoid ESM import issues in Jest
+jest.mock('jose', () => ({
+  EncryptJWT: jest.fn().mockImplementation(() => ({
+    setProtectedHeader: jest.fn().mockReturnThis(),
+    setIssuedAt: jest.fn().mockReturnThis(),
+    setExpirationTime: jest.fn().mockReturnThis(),
+    encrypt: jest.fn().mockResolvedValue('mock-encrypted-token'),
+  })),
+}));
+
+// --- Mocks -----------------------------------------------------------
+
+const mockRedirect = jest.fn((url: string | URL) => ({
+  status: 302,
+  headers: { location: typeof url === 'string' ? url : url.toString() },
+  cookies: { set: jest.fn() },
+}));
+
+const mockJson = jest.fn((body: any, init?: { status?: number }) => ({
+  status: init?.status ?? 200,
+  body,
+}));
+
+jest.mock('next/server', () => {
+  class NextURL extends URL {
+    get origin() { return new URL(this.href).origin; }
+  }
+  class NextRequest {
+    url: string;
+    nextUrl: NextURL;
+    constructor(url: string) {
+      this.url = url;
+      this.nextUrl = new NextURL(url);
+    }
+  }
+  return {
+    NextRequest,
+    NextResponse: {
+      redirect: mockRedirect,
+      json: mockJson,
+    },
+  };
+});
+
+// --- Tests -----------------------------------------------------------
+
+describe('GitHub OAuth redirect_uri', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    mockRedirect.mockClear();
+    mockJson.mockClear();
+    process.env = { ...ORIGINAL_ENV };
+    process.env.GITHUB_CLIENT_ID = 'test-client-id';
+    process.env.GITHUB_CLIENT_SECRET = 'test-client-secret';
+    process.env.SESSION_SECRET = 'a]é'.padEnd(32, 'x'); // 32+ chars
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  describe('/api/github/auth/request', () => {
+    it('should use the request origin, not NEXT_PUBLIC_APP_URL, for redirect_uri', async () => {
+      process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:8888';
+
+      const { GET } = await import('../request/route');
+      const request = new Request('https://weval.org/api/github/auth/request');
+      await GET(request);
+
+      expect(mockRedirect).toHaveBeenCalledTimes(1);
+      const redirectUrl = mockRedirect.mock.calls[0][0];
+      expect(redirectUrl).toContain('redirect_uri=');
+      expect(redirectUrl).toContain(encodeURIComponent('https://weval.org/api/github/auth/callback'));
+      expect(redirectUrl).not.toContain('localhost');
+    });
+
+    it('should use localhost origin when running locally', async () => {
+      const { GET } = await import('../request/route');
+      const request = new Request('http://localhost:3000/api/github/auth/request');
+      await GET(request);
+
+      expect(mockRedirect).toHaveBeenCalledTimes(1);
+      const redirectUrl = mockRedirect.mock.calls[0][0];
+      expect(redirectUrl).toContain(encodeURIComponent('http://localhost:3000/api/github/auth/callback'));
+    });
+
+    it('should return 500 if GITHUB_CLIENT_ID is missing', async () => {
+      delete process.env.GITHUB_CLIENT_ID;
+
+      const { GET } = await import('../request/route');
+      const request = new Request('https://weval.org/api/github/auth/request');
+      await GET(request);
+
+      expect(mockJson).toHaveBeenCalledTimes(1);
+      expect(mockJson.mock.calls[0][1]).toEqual({ status: 500 });
+    });
+  });
+
+  describe('/api/github/auth/callback', () => {
+    it('should use the request origin, not NEXT_PUBLIC_APP_URL, for redirect_uri in token exchange', async () => {
+      process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:8888';
+
+      const mockTokenResponse = { access_token: 'gho_test_token_123' };
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve(mockTokenResponse),
+      });
+
+      const { NextRequest } = await import('next/server');
+      const { GET } = await import('../callback/route');
+      const req = new NextRequest('https://weval.org/api/github/auth/callback?code=test-code');
+      await GET(req as any);
+
+      // Verify the token exchange used the correct origin
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+      const fetchBody = JSON.parse(fetchCall[1].body);
+      expect(fetchBody.redirect_uri).toBe('https://weval.org/api/github/auth/callback');
+      expect(fetchBody.redirect_uri).not.toContain('localhost');
+    });
+
+    it('should redirect to the request origin after successful login', async () => {
+      process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:8888';
+
+      const mockTokenResponse = { access_token: 'gho_test_token_123' };
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve(mockTokenResponse),
+      });
+
+      const { NextRequest } = await import('next/server');
+      const { GET } = await import('../callback/route');
+      const req = new NextRequest('https://weval.org/api/github/auth/callback?code=test-code');
+      await GET(req as any);
+
+      // The final redirect should go to the request origin, not NEXT_PUBLIC_APP_URL
+      const redirectUrl = mockRedirect.mock.calls[0][0];
+      const redirectStr = typeof redirectUrl === 'string' ? redirectUrl : redirectUrl.toString();
+      expect(redirectStr).toContain('weval.org');
+      expect(redirectStr).not.toContain('localhost:8888');
+    });
+  });
+});

--- a/src/app/api/github/auth/callback/route.ts
+++ b/src/app/api/github/auth/callback/route.ts
@@ -34,29 +34,27 @@ export async function GET(req: NextRequest) {
   const clientId = process.env.GITHUB_CLIENT_ID;
   const clientSecret = process.env.GITHUB_CLIENT_SECRET;
   const sessionSecret = process.env.SESSION_SECRET;
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
 
   console.log("[Auth Callback] Verifying environment variable presence and content:");
   console.table({
     GITHUB_CLIENT_ID: clientId ? `Present (Value: ${clientId})` : 'Missing',
     GITHUB_CLIENT_SECRET: clientSecret ? `Present (Ends with: ...${clientSecret.slice(-4)})` : 'Missing',
     SESSION_SECRET: sessionSecret ? `Present (Length: ${sessionSecret.length})` : 'Missing',
-    NEXT_PUBLIC_APP_URL: appUrl ? `Present (Value: ${appUrl})` : 'Missing',
   });
 
-  if (!clientId || !clientSecret || !sessionSecret || !appUrl) {
+  if (!clientId || !clientSecret || !sessionSecret) {
     const missingVars = [
       !clientId && 'GITHUB_CLIENT_ID',
       !clientSecret && 'GITHUB_CLIENT_SECRET',
       !sessionSecret && 'SESSION_SECRET',
-      !appUrl && 'NEXT_PUBLIC_APP_URL',
     ].filter(Boolean);
 
     console.error(`[Auth Callback] Server Configuration Error: Aborting because the following environment variables are missing: ${missingVars.join(', ')}`);
     return NextResponse.redirect(new URL('/sandbox?error=' + encodeURIComponent('Server configuration error.'), req.nextUrl.origin));
   }
 
-  const redirect_uri = `${appUrl}/api/github/auth/callback`;
+  const origin = req.nextUrl.origin;
+  const redirect_uri = `${origin}/api/github/auth/callback`;
   console.log(`[Auth Callback] Using redirect_uri for token exchange: ${redirect_uri}`);
 
   try {
@@ -88,9 +86,7 @@ export async function GET(req: NextRequest) {
     // Encrypt the token before storing it in the cookie
     const encryptedToken = await encryptToken(accessToken, sessionSecret);
 
-    // Always redirect to production URL (weval.org) after successful login
-    // This ensures users end up on the canonical domain regardless of where they started
-    const nextResponse = NextResponse.redirect(new URL('/sandbox', appUrl));
+    const nextResponse = NextResponse.redirect(new URL('/sandbox', origin));
 
     nextResponse.cookies.set('github_session', encryptedToken, {
         httpOnly: true,
@@ -99,12 +95,11 @@ export async function GET(req: NextRequest) {
         path: '/',
     });
 
-    console.log(`[Auth Callback] GitHub authentication successful. Redirecting to ${appUrl}/sandbox`);
+    console.log(`[Auth Callback] GitHub authentication successful. Redirecting to ${origin}/sandbox`);
     return nextResponse;
 
   } catch (err: any) {
     console.error('[Auth Callback] Final exception caught:', err);
-    // Use appUrl for error redirect too (we're past validation at this point)
-    return NextResponse.redirect(new URL('/sandbox?error=' + encodeURIComponent(err.message), appUrl));
+    return NextResponse.redirect(new URL('/sandbox?error=' + encodeURIComponent(err.message), origin));
   }
 } 

--- a/src/app/api/github/auth/request/route.ts
+++ b/src/app/api/github/auth/request/route.ts
@@ -4,15 +4,10 @@ export const dynamic = 'force-dynamic';
 
 export async function GET(request: Request) {
   const clientId = process.env.GITHUB_CLIENT_ID;
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
 
-  if (!clientId || !appUrl) {
-    const missingVars = [
-      !clientId && 'GITHUB_CLIENT_ID',
-      !appUrl && 'NEXT_PUBLIC_APP_URL',
-    ].filter(Boolean);
-    console.error(`[Auth Request] Server Configuration Error: Aborting because the following environment variables are missing: ${missingVars.join(', ')}`);
-    return NextResponse.json({ error: 'GitHub Client ID or App URL not configured in environment.' }, { status: 500 });
+  if (!clientId) {
+    console.error(`[Auth Request] Server Configuration Error: Aborting because GITHUB_CLIENT_ID is missing.`);
+    return NextResponse.json({ error: 'GitHub Client ID not configured in environment.' }, { status: 500 });
   }
 
   // The 'public_repo' scope allows creating forks and PRs for public repositories.
@@ -21,7 +16,8 @@ export async function GET(request: Request) {
   const scopes = ['public_repo', 'read:org'];
   const scopeString = scopes.join(' ');
 
-  const redirect_uri = `${appUrl}/api/github/auth/callback`;
+  const origin = new URL(request.url).origin;
+  const redirect_uri = `${origin}/api/github/auth/callback`;
 
   const params = new URLSearchParams({
     client_id: clientId,


### PR DESCRIPTION
> **Note:** This fix was vibecoded.

## Problem

Fixes #4

The GitHub OAuth flow redirects users to `http://localhost:8888/api/github/auth/callback` instead of the production URL, causing `ERR_CONNECTION_REFUSED` and preventing GitHub account linking.

Both `/api/github/auth/request` and `/api/github/auth/callback` were constructing the `redirect_uri` from `NEXT_PUBLIC_APP_URL`, which defaults to `http://localhost:8888` in [.env.template](cci:7://file:///Users/jesper/Documents/GitHub/wevalapp/.env.template:0:0-0:0). If this isn't overridden in production, the entire OAuth flow breaks silently.

## Fix

Derive the OAuth `redirect_uri` from the **incoming request's origin** instead of `NEXT_PUBLIC_APP_URL`:

- `/api/github/auth/request` → `new URL(request.url).origin`
- `/api/github/auth/callback` → [req.nextUrl.origin](cci:1://file:///Users/jesper/Documents/GitHub/wevalapp/src/app/api/github/auth/__tests__/oauth-redirect.test.ts:34:4-34:54)

This means the correct URL is always used automatically:
- On `https://weval.org` → `https://weval.org/api/github/auth/callback`
- On `http://localhost:8888` → `http://localhost:8888/api/github/auth/callback`

## Changes

- **[src/app/api/github/auth/request/route.ts](cci:7://file:///Users/jesper/Documents/GitHub/wevalapp/src/app/api/github/auth/request/route.ts:0:0-0:0)** — Use `new URL(request.url).origin` for `redirect_uri`. Remove `NEXT_PUBLIC_APP_URL` from required env var check.
- **[src/app/api/github/auth/callback/route.ts](cci:7://file:///Users/jesper/Documents/GitHub/wevalapp/src/app/api/github/auth/callback/route.ts:0:0-0:0)** — Use [req.nextUrl.origin](cci:1://file:///Users/jesper/Documents/GitHub/wevalapp/src/app/api/github/auth/__tests__/oauth-redirect.test.ts:34:4-34:54) for `redirect_uri` and all post-login redirects. Remove `NEXT_PUBLIC_APP_URL` from required env var check.
- **[src/app/api/github/auth/__tests__/oauth-redirect.test.ts](cci:7://file:///Users/jesper/Documents/GitHub/wevalapp/src/app/api/github/auth/__tests__/oauth-redirect.test.ts:0:0-0:0)** — Regression tests verifying the redirect_uri is derived from the request origin.

## Security

- No meaningful security regression. This is a common pattern for OAuth implementations.
- GitHub's own OAuth App callback URL whitelist provides the real security boundary — it will reject any `redirect_uri` that doesn't match the registered callback URL(s).
- Reverse proxies (Netlify, etc.) set the `Host` header correctly, preventing spoofed origins.

## Notes

`NEXT_PUBLIC_APP_URL` is still used elsewhere in the codebase (background functions, metadata, etc.) and should still be configured correctly in production. It is just no longer a dependency of the OAuth flow.