### PR TITLE
fix: staging/prod deploy failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "next dev -p 3172",
     "build": "NODE_OPTIONS=--max-old-space-size=6144 next build",
     "build:debug": "NODE_OPTIONS=--max-old-space-size=6144 next build --profile --experimental-debug-memory-usage",
-    "start": "NODE_OPTIONS=--max-old-space-size=6144 next start -p 3172",
+    "start": "NODE_OPTIONS=--max-old-space-size=6144 next start -p ${PORT:-3172}",
     "lint": "next lint",
     "lint:fix": "next lint --fix",
     "analyze": "ANALYZE=true pnpm run build",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "llm-sim-suite",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@9.6.0",
   "pnpm": {
     "onlyBuiltDependencies": [
       "@sentry-internal/node-cpu-profiler",


### PR DESCRIPTION
## Changes

Prod/stage deploys are failing with 
```
fetching snapshot
2.3 MB
73ms
using build driver railpack-v0.23.0
                   
╭─────────────────╮
│ Railpack 0.23.0 │
╰─────────────────╯
 
  ↳ Detected Node
  ↳ Using pnpm package manager
  ✖ Failed to resolve version 9 of pnpm
 
 
railpack process exited with an error
```

because we have not specified a package manager. likely, this was a change on Railway's infrastructure side