### PR TITLE
[Bug] Capitalize tag-based filter button labels on homepage

### DIFF
--- a/src/app/components/home/EvaluationFilterSection.tsx
+++ b/src/app/components/home/EvaluationFilterSection.tsx
@@ -53,7 +53,7 @@ export default function EvaluationFilterSection({
           <button
             key={pill.key}
             onClick={() => setActiveFilter(pill.key)}
-            className={`flex-shrink-0 px-4 py-1.5 rounded-full text-sm font-medium transition-colors border ${
+            className={`flex-shrink-0 px-4 py-1.5 rounded-full text-sm font-medium transition-colors border capitalize ${
               activeFilter === pill.key
                 ? 'bg-foreground text-background border-foreground'
                 : 'bg-transparent text-foreground/70 border-border hover:border-foreground/50 hover:text-foreground'


### PR DESCRIPTION
# Description
Fixes a display bug where tag-based filter buttons on the homepage rendered in lowercase (e.g. "safety" instead of "Safety").

**Before:**
<img width="385" height="81" alt="image" src="https://github.com/user-attachments/assets/1920cf64-ed24-4e59-a5fa-05a08aa7f1b8" />

   ## Summary
   - Tag names sourced from blueprint YAML are lowercase strings. `EvaluationFilterSection` was passing the raw tag name directly as the pill label with no capitalization applied.
   - Adds Tailwind's `capitalize` utility class to the pill button, consistent with how the rest of the codebase handles this pattern (see `MacroCoverageTable`, `SharedEvaluationComponents`). The filter `key` is unchanged so filtering behaviour is unaffected — display only.


Fixes in-app bug report from nnojibe@gmail.com.

Closes: https://github.com/weval-org/app/issues/17


   > PR written with assistance from Claude (Anthropic).