### PR TITLE
[Bug] Make Runs/Blueprints tooltips functional on model card page

### DIFF
--- a/src/app/(standard)/cards/[modelId]/PerformanceSummaryStats.tsx
+++ b/src/app/(standard)/cards/[modelId]/PerformanceSummaryStats.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip';
+import Icon from '@/components/ui/icon';
+
+interface Props {
+  totalRuns: number;
+  totalBlueprints: number;
+}
+
+export default function PerformanceSummaryStats({ totalRuns, totalBlueprints }: Props) {
+  return (
+    <TooltipProvider delayDuration={200}>
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center">
+            <Icon name="activity" className="h-3.5 w-3.5 text-muted-foreground mr-2" />
+            <Tooltip>
+              <TooltipTrigger className="flex items-center gap-1 text-sm cursor-help underline-offset-4 hover:underline decoration-dotted">
+                Runs
+                <Icon name="info" className="h-3 w-3 text-muted-foreground" />
+              </TooltipTrigger>
+              <TooltipContent>
+                Number of times this model was evaluated across all blueprints
+              </TooltipContent>
+            </Tooltip>
+          </div>
+          <span className="font-medium">{totalRuns}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center">
+            <Icon name="users" className="h-3.5 w-3.5 text-muted-foreground mr-2" />
+            <Tooltip>
+              <TooltipTrigger className="flex items-center gap-1 text-sm cursor-help underline-offset-4 hover:underline decoration-dotted">
+                Blueprints
+                <Icon name="info" className="h-3 w-3 text-muted-foreground" />
+              </TooltipTrigger>
+              <TooltipContent>
+                Distinct evaluation blueprints/configs this model was tested on
+              </TooltipContent>
+            </Tooltip>
+          </div>
+          <span className="font-medium">{totalBlueprints}</span>
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/src/app/(standard)/cards/[modelId]/page.tsx
+++ b/src/app/(standard)/cards/[modelId]/page.tsx
@@ -8,7 +8,7 @@ import Link from 'next/link';
 import Icon, { type IconName } from '@/components/ui/icon';
 import ResponseRenderer from '@/app/components/ResponseRenderer';
 import RemarkGfmPlugin from 'remark-gfm';
-import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip';
+import PerformanceSummaryStats from './PerformanceSummaryStats';
 
 // Shared formatters
 const formatPercent = (value?: number | null, fractionDigits = 1): string => {
@@ -285,41 +285,13 @@ export default async function ModelCardPage({ params }: ModelCardPageProps) {
 
             {/* Right Column - Stats & Metadata (Secondary) */}
             <div className="lg:w-80 bg-muted/10 border-t lg:border-t-0 lg:border-l border-border p-6 lg:sticky lg:top-4 self-start">
-              <TooltipProvider>
-              
               {/* Quick Stats */}
               <div className="mb-6">
                 <h3 className="font-medium text-sm text-muted-foreground mb-3">Performance Summary</h3>
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center">
-                        <Icon name="activity" className="h-3.5 w-3.5 text-muted-foreground mr-2" />
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <span className="text-sm cursor-help">Runs</span>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          Number of times this model was evaluated across all blueprints
-                        </TooltipContent>
-                      </Tooltip>
-                    </div>
-                    <span className="font-medium">{modelCard.overallStats.totalRuns}</span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center">
-                      <Icon name="users" className="h-3.5 w-3.5 text-muted-foreground mr-2" />
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <span className="text-sm cursor-help">Blueprints</span>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          Distinct evaluation blueprints/configs this model was tested on
-                        </TooltipContent>
-                      </Tooltip>
-                    </div>
-                    <span className="font-medium">{modelCard.overallStats.totalBlueprints}</span>
-                  </div>
-                </div>
+                <PerformanceSummaryStats
+                  totalRuns={modelCard.overallStats.totalRuns}
+                  totalBlueprints={modelCard.overallStats.totalBlueprints}
+                />
               </div>
 
               {/* Top Dimensional Performance */}
@@ -496,7 +468,6 @@ export default async function ModelCardPage({ params }: ModelCardPageProps) {
               <div className="text-center">
                 <div className="text-xs text-muted-foreground">Updated {new Date(modelCard.lastUpdated).toLocaleDateString()}</div>
               </div>
-              </TooltipProvider>
             </div>
           </div>
         </div>


### PR DESCRIPTION
# Description                                                                                                                            
Fixes a bug where the "Runs" and "Blueprints" tooltip triggers in the Performance Summary on `/cards/{model}` pages would not render at times. It would just show the cursor.

Now:
<img width="455" height="110" alt="Screenshot 2026-05-05 at 10 54 18 AM" src="https://github.com/user-attachments/assets/b178f9d5-378b-4014-8082-3c6a7b0a9897" />

<img width="429" height="112" alt="Screenshot 2026-05-05 at 10 54 04 AM" src="https://github.com/user-attachments/assets/f381bf0a-3a41-4e71-b15a-d437134a3941" />
                                                                                                                                         
## Summary

### Root cause
`cards/[modelId]/page.tsx` is a Server Component, and Radix UI Tooltip needs a client boundary to hydrate — without one, the triggers mount, but the popover never attaches, with no error.

### Fix
 Extracted the Performance Summary stats into a small Client Component (`PerformanceSummaryStats.tsx`) so only that sub-tree opts into a client boundary, rather than converting the whole page.

### Additional Change
Added the "info" icon to clarify that hovering will render a tooltip.

                                                                                                                                         
## Testing                                                      

  - Navigate to https://weval.org/cards/claude-sonnet-4 (or any model card)                                                              
  - Hover over "Runs" and "Blueprints" in the Performance Summary
  - Confirm tooltips now appear on hover                                                                                                 
  - Confirm cursor-help (question mark cursor) is present on hover
                                                                                                                                         
  Fixes in-app bug report from nnojibe@gmail.com.

Closes https://github.com/weval-org/app/issues/15                                                                                      
                                                                                                                                         
  ▎ PR written with assistance from Claude (Anthropic).