### PR TITLE
fix: custom model objects with id field skipped in resolveModelCollections

### DIFF
--- a/src/cli/commands/run-config.ts
+++ b/src/cli/commands/run-config.ts
@@ -68,6 +68,9 @@ export async function resolveModelCollections(configModels: any[], collectionsRe
                 logger.warn(`Malformed model entry string '${modelEntry}' contains unexpected whitespace. Correcting to '${correctedEntry}'. Please fix this in your blueprint file.`);
             }
             normalizedConfigModels.push(correctedEntry);
+        } else if (typeof modelEntry === 'object' && modelEntry !== null && !Array.isArray(modelEntry) && modelEntry.id) {
+            // This is a custom model definition (has id, url, modelName, inherit). Add it directly.
+            normalizedConfigModels.push(modelEntry);
         } else if (typeof modelEntry === 'object' && modelEntry !== null && !Array.isArray(modelEntry)) {
             const keys = Object.keys(modelEntry);
             if (keys.length === 1) {
@@ -85,9 +88,6 @@ export async function resolveModelCollections(configModels: any[], collectionsRe
             } else {
                 logger.warn(`Invalid object entry in models array: Must have exactly one key (the provider). Found ${keys.length} keys. Skipping: ${JSON.stringify(modelEntry)}.`);
             }
-        } else if (typeof modelEntry === 'object' && modelEntry !== null && !Array.isArray(modelEntry) && modelEntry.id) {
-            // This is a custom model definition. Add it directly.
-            normalizedConfigModels.push(modelEntry);
         } else {
              logger.warn(`Invalid entry in models array found: ${JSON.stringify(modelEntry)}. It is not a string or a single key-value object. Skipping this entry.`);
         }


### PR DESCRIPTION
Fixes weval-org/app#22

When defining a custom model in a blueprint using object syntax with multiple fields (e.g. `id`, `url`, `modelName`, `inherit`), the model is silently skipped during resolution and a warning is logged instead.

> **Note:** No Blueprint ID applicable — this is a code-level bug in `resolveModelCollections`, reproducible with any blueprint defining a custom model object with an `id` field.

## To reproduce

Define a custom model in a blueprint:

```yaml
models:
  - id: my-custom-agent
    url: http://localhost:3001/v1
    modelName: gpt-4o
```

Run an evaluation. The model is not included — instead you see:

```
Invalid object entry in models array: Must have exactly one key (the provider). Found 3 keys. Skipping: {"id":"my-custom-agent","url":"...","modelName":"gpt-4o"}
```

## Expected behavior

Custom model objects with an `id` field should be passed through directly and included in the evaluation.

## Root cause

In `src/cli/commands/run-config.ts`, `resolveModelCollections` checks for a generic single-key provider object *before* checking for a custom model object with an `id` property. Since a custom model has multiple keys, it fails the single-key check and is skipped.

The fix is to check for `modelEntry.id` first:

```ts
} else if (typeof modelEntry === 'object' && modelEntry !== null && !Array.isArray(modelEntry) && modelEntry.id) {
    // Custom model definition — pass through directly
    normalizedConfigModels.push(modelEntry);
} else if (typeof modelEntry === 'object' && modelEntry !== null && !Array.isArray(modelEntry)) {
    // Provider shorthand — expect exactly one key
    ...
```

## Additional context

No error is thrown — the silent skip makes this hard to diagnose without reading the warning carefully. Fix is available in [frantj/wevalapp@339c52a](https://github.com/frantj/wevalapp/commit/339c52a).
