### PR TITLE
fix: report clear size-limit errors for oversized blueprints in webhooks

### DIFF
--- a/src/app/api/webhooks/github-pr/route.ts
+++ b/src/app/api/webhooks/github-pr/route.ts
@@ -125,7 +125,7 @@ function parseBlueprintFiles(files: any[], prAuthor: string): {
 /**
  * Fetch blueprint content from GitHub
  */
-async function fetchBlueprintContent(octokit: Octokit, owner: string, repo: string, ref: string, path: string): Promise<string | null> {
+async function fetchBlueprintContent(octokit: Octokit, owner: string, repo: string, ref: string, path: string): Promise<{ content: string | null; error?: string }> {
   try {
     const response = await octokit.repos.getContent({
       owner,
@@ -135,20 +135,23 @@ async function fetchBlueprintContent(octokit: Octokit, owner: string, repo: stri
     });
 
     if ('content' in response.data && response.data.type === 'file') {
-      const content = Buffer.from(response.data.content, 'base64').toString('utf-8');
-
-      // Check size limit
-      const sizeKB = Buffer.byteLength(content, 'utf-8') / 1024;
+      // Check size limit using the API-reported size. For files over 1MB the
+      // Contents API returns `encoding: "none"` with empty content, so the
+      // reported size is the only reliable measure.
+      const sizeKB = response.data.size / 1024;
       if (sizeKB > MAX_BLUEPRINT_SIZE_KB) {
-        throw new Error(`Blueprint exceeds size limit (${sizeKB.toFixed(1)}KB > ${MAX_BLUEPRINT_SIZE_KB}KB)`);
+        return {
+          content: null,
+          error: `Blueprint is ${sizeKB.toFixed(1)}KB, which exceeds the ${MAX_BLUEPRINT_SIZE_KB}KB limit. Please split it into smaller files.`,
+        };
       }
 
-      return content;
+      return { content: Buffer.from(response.data.content, 'base64').toString('utf-8') };
     }
-    return null;
+    return { content: null, error: 'Path did not resolve to a file' };
   } catch (error: any) {
     console.error(`[GitHub Webhook] Failed to fetch content for ${path}:`, error.message);
-    return null;
+    return { content: null, error: 'Failed to fetch blueprint content' };
   }
 }
 
@@ -407,7 +410,7 @@ export async function POST(req: NextRequest) {
 
     for (const file of valid) {
       // Fetch content from PR head
-      const content = await fetchBlueprintContent(
+      const { content, error: fetchError } = await fetchBlueprintContent(
         octokit,
         pr.head.repo.owner.login,
         pr.head.repo.name,
@@ -416,7 +419,7 @@ export async function POST(req: NextRequest) {
       );
 
       if (!content) {
-        validationErrors.push({ filename: file.filename, error: 'Failed to fetch blueprint content' });
+        validationErrors.push({ filename: file.filename, error: fetchError || 'Failed to fetch blueprint content' });
         continue;
       }
 

--- a/src/app/api/webhooks/github-push/route.ts
+++ b/src/app/api/webhooks/github-push/route.ts
@@ -11,6 +11,7 @@ const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const UPSTREAM_OWNER = 'weval-org';
 const UPSTREAM_REPO = 'configs';
 const MAIN_BRANCH = 'main';
+const MAX_BLUEPRINT_SIZE_KB = 500; // 500KB max, matches the PR webhook limit
 
 const s3Client = new S3Client({
   region: process.env.APP_S3_REGION!,
@@ -101,7 +102,7 @@ async function fetchBlueprintContent(
   repo: string,
   ref: string,
   path: string
-): Promise<string | null> {
+): Promise<{ content: string | null; error?: string }> {
   try {
     const response = await octokit.repos.getContent({
       owner,
@@ -111,12 +112,23 @@ async function fetchBlueprintContent(
     });
 
     if ('content' in response.data && response.data.type === 'file') {
-      return Buffer.from(response.data.content, 'base64').toString('utf-8');
+      // Check size limit using the API-reported size. For files over 1MB the
+      // Contents API returns `encoding: "none"` with empty content, so the
+      // reported size is the only reliable measure.
+      const sizeKB = response.data.size / 1024;
+      if (sizeKB > MAX_BLUEPRINT_SIZE_KB) {
+        return {
+          content: null,
+          error: `Blueprint is ${sizeKB.toFixed(1)}KB, which exceeds the ${MAX_BLUEPRINT_SIZE_KB}KB limit`,
+        };
+      }
+
+      return { content: Buffer.from(response.data.content, 'base64').toString('utf-8') };
     }
-    return null;
+    return { content: null, error: 'Path did not resolve to a file' };
   } catch (error: any) {
     console.error(`[GitHub Push Webhook] Failed to fetch ${path}:`, error.message);
-    return null;
+    return { content: null, error: 'Failed to fetch blueprint content' };
   }
 }
 
@@ -308,7 +320,7 @@ export async function POST(req: NextRequest) {
       console.log(`[GitHub Push Webhook] Processing ${file.filename}...`);
 
       // Fetch content
-      const content = await fetchBlueprintContent(
+      const { content, error: fetchError } = await fetchBlueprintContent(
         octokit,
         UPSTREAM_OWNER,
         UPSTREAM_REPO,
@@ -317,8 +329,8 @@ export async function POST(req: NextRequest) {
       );
 
       if (!content) {
-        console.error(`[GitHub Push Webhook] Failed to fetch content for ${file.filename}`);
-        results.errors.push(`${file.filename}: Failed to fetch content`);
+        console.error(`[GitHub Push Webhook] Failed to fetch content for ${file.filename}: ${fetchError}`);
+        results.errors.push(`${file.filename}: ${fetchError || 'Failed to fetch content'}`);
         continue;
       }
 


### PR DESCRIPTION
## What changed

Both GitHub webhooks (`github-pr` and `github-push`) now report a clear, actionable error when a blueprint exceeds the 500KB size limit, instead of the generic `Failed to fetch blueprint content`.

- `fetchBlueprintContent` checks the API-reported `size` field **before** decoding content, and returns `{ content, error }` instead of `string | null` so the specific error reaches the PR comment.
- The push webhook gets the same 500KB check (it previously had none).

## Why

Two compounding bugs produced the useless generic error, seen on [configs#27](https://github.com/weval-org/configs/pull/27) (~1.6MB) and [configs#28](https://github.com/weval-org/configs/pull/28) (~1.14MB):

1. **Files over 1MB bypassed the size check entirely.** The GitHub Contents API returns `encoding: "none"` with empty `content` for files over 1MB. Decoding empty base64 yields `""`, which measured 0KB, passed the 500KB check, then surfaced as a falsy-content generic failure.
2. **Files between 500KB and 1MB lost their error message.** The size check threw a descriptive error, but the catch block swallowed it and returned `null`.

Contributors now see e.g. *"Blueprint is 1632.5KB, which exceeds the 500KB limit. Please split it into smaller files."*

## Reviewer notes

- The 500KB policy is unchanged — this is error-reporting only. No blob-API fallback was added since >500KB files are rejected by policy anyway.
- `response.data.size` is always populated by the Contents API, even when content isn't inlined, so it's the reliable measure.
- I was unable to run `tsc --noEmit` locally (no Node toolchain on this machine) — both call sites were updated by inspection; please let CI confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)