### PR TITLE
Match header logo size to the /about header

### DIFF
--- a/src/app/components/SiteHeader.tsx
+++ b/src/app/components/SiteHeader.tsx
@@ -14,7 +14,7 @@ export function SiteHeader({ contentMaxWidth = 'max-w-7xl' }: SiteHeaderProps) {
       <div className={cn("mx-auto px-4 sm:px-6 lg:px-8", contentMaxWidth)}>
         <div className="flex items-center justify-between">
           <Link href="/" className="flex items-center gap-2 group">
-            <CIPLogo className="w-5 h-5 text-foreground" />
+            <CIPLogo className="w-6 h-6 sm:w-7 sm:h-7 text-foreground" />
             <span className="font-bold text-foreground group-hover:underline">Weval</span>
             <span className="font-normal text-muted-foreground group-hover:underline">a Collective Intelligence Project</span>
           </Link>


### PR DESCRIPTION
## Summary
- The Weval logo in the site header (`SiteHeader`) rendered smaller than the same logo on the `/about` page.
- Home/site header used `w-5 h-5` (20px); `/about` uses `w-6 h-6 sm:w-7 sm:h-7` (24px, 28px at `sm`+).
- Bumped `SiteHeader` to the same `w-6 h-6 sm:w-7 sm:h-7` sizing so the logo is consistent across the site.

## Test plan
- [ ] Load `/` and `/about` side by side -- the logo next to "Weval" should be the same size on both.
- [ ] Resize from mobile to desktop width -- logo should grow from 24px to 28px at the `sm` breakpoint on both pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)