### PR TITLE
fix: allow sqlite3 native build script in pnpm config

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "@sentry-internal/node-cpu-profiler",
-      "@sentry/cli"
+      "@sentry/cli",
+      "sqlite3"
     ]
   },
   "scripts": {


### PR DESCRIPTION
sqlite3's postinstall build script was being skipped by pnpm's default onlyBuiltDependencies allowlist, leaving the native binding unbuilt. This silently disables the SQLite-backed response cache (falls back to in-memory, non-persistent cache) with a console warning on startup.

Adding sqlite3 to onlyBuiltDependencies ensures the native binding is built on install.