### PR TITLE
CI: run typecheck, lint & Vitest suites on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,106 @@
+name: CI
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # `next lint` prompts interactively to configure ESLint when no ESLint
+      # config or eslint deps are present in the repo, which would hang CI.
+      # The repo currently ships no ESLint config, so guard the lint step:
+      # run it only when a config exists, otherwise emit a warning and pass
+      # (rather than hang, or fail every PR over a pre-existing gap that is
+      # out of scope for this workflow). Once an ESLint config + the eslint /
+      # eslint-config-next devDependencies are added, this job lints normally.
+      - name: Lint
+        run: |
+          if ls .eslintrc* eslint.config.* >/dev/null 2>&1; then
+            echo "ESLint config found; running lint."
+            pnpm lint
+          else
+            echo "::warning title=Lint skipped::No ESLint config found (.eslintrc* / eslint.config.*). \`next lint\` would prompt interactively to set up ESLint. Add an ESLint config and the eslint / eslint-config-next devDependencies to enable this gate."
+          fi
+
+  test-web:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run web test suite
+        run: pnpm test:web
+
+  test-cli:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run CLI test suite
+        run: pnpm test:cli


### PR DESCRIPTION
Closes #33

## Stacking

This PR is **stacked on #46** (the Jest→Vitest migration, issue #45), so its base is `claude/vitest-migration-45` and the diff is limited to the single new workflow file. Once #46 merges, GitHub will automatically retarget this PR to `main`.

## Summary

Adds `.github/workflows/ci.yml` — a CI workflow that runs the project's quality gates on pull requests and on pushes to `main`.

- **Triggers:** `pull_request` and `push` to `main`, both with `paths-ignore` for `**/*.md` and `docs/**` (mirrors `e2e.yml`).
- **Concurrency:** group keyed on `github.ref` with `cancel-in-progress: true`.
- **Common setup (each job):** checkout → `pnpm/action-setup@v4` → `actions/setup-node@v4` with `node-version-file: '.nvmrc'` (Node 18) and `cache: pnpm` → `pnpm install --frozen-lockfile`.
- **Gates as separate parallel jobs** so failures are isolated:
  - `typecheck` → `pnpm typecheck`
  - `lint` → `pnpm lint` (guarded; see caveat)
  - `test-web` → `pnpm test:web`
  - `test-cli` → `pnpm test:cli`

## Verified locally (on this branch)

- YAML is well-formed.
- All four referenced scripts exist in `package.json`.
- `pnpm typecheck` → passes (exit 0).
- `pnpm test:web` → 49 files, 596 passed / 1 skipped.
- `pnpm test:cli` → 45 files, 519 passed / 1 skipped.

## Lint caveat

The repo currently ships **no ESLint config** (`.eslintrc*` / `eslint.config.*`) and no `eslint` / `eslint-config-next` devDependencies. As a result `next lint` prompts interactively ("How would you like to configure ESLint?") and would hang CI — confirmed locally even with stdin closed.

To avoid hanging CI or failing every PR over a pre-existing gap that is out of scope for this ticket, the `lint` job is guarded: it runs `pnpm lint` only when an ESLint config is present, otherwise it emits a GitHub warning annotation and passes. The other three gates are unaffected and fully enforced. Once an ESLint config and the corresponding devDependencies are added (best tracked as a separate follow-up), the guard becomes a no-op and lint runs normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9z5V7UM3FhqomggQ3XTVG

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9z5V7UM3FhqomggQ3XTVG)_