### PR TITLE
test(useGitHub): fix and unskip the missing-branchName test

### DIFF
--- a/src/app/sandbox/hooks/useGitHub.test.ts
+++ b/src/app/sandbox/hooks/useGitHub.test.ts
@@ -229,16 +229,25 @@ describe('useGitHub', () => {
             expect(updatedFile?.sha).toBe('updated-sha');
         });
 
-        // NOTE: This test is stale relative to the current source: updateFileOnGitHub returns
-        // null (after showing a toast) when branchName is missing rather than throwing, so the
-        // .rejects.toThrow assertion fails on main too. The unit suites are not run in CI, so
-        // the drift went unnoticed. Skipping to avoid masking it as a migration regression.
-        test.skip('should throw an error if branchName is missing', async () => {
+        // updateFileOnGitHub treats a missing branchName as a graceful no-op: it shows a
+        // destructive toast and returns null (its return type is BlueprintFile | null, and
+        // every other guard path behaves the same way). Assert that contract rather than a throw.
+        test('should return null and show a toast if branchName is missing', async () => {
              const { result } = renderHook(() => useGitHub(true, 'test-user'));
              await act(async () => {
                 result.current.setForkName('test-user-fork');
             });
-            await expect(result.current.updateFileOnGitHub(mockBlueprint.path, 'new content', mockBlueprint.sha, '')).rejects.toThrow('A branch name is required to update a file on GitHub.');
+            let updatedFile: BlueprintFile | null = null;
+            await act(async () => {
+                updatedFile = await result.current.updateFileOnGitHub(mockBlueprint.path, 'new content', mockBlueprint.sha, '');
+            });
+            expect(updatedFile).toBeNull();
+            expect(mockToast).toHaveBeenCalledWith({
+                variant: 'destructive',
+                title: 'Branch Required',
+                description: 'A branch name is required to update a file on GitHub. This is a technical error - please refresh the page.',
+            });
+            expect(fetch).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
## Summary

Fixes the skipped `useGitHub` test called out in #49.

`should throw an error if branchName is missing` was `.skip`ped during the Jest→Vitest migration (#45 / PR #46) because it asserted a throw, but `updateFileOnGitHub` actually **returns `null`** (after showing a destructive "Branch Required" toast) when `branchName` is missing.

Fixes #49

## Decision: keep the source, fix the test

Returning `null` is the intended contract, not a bug:

- `updateFileOnGitHub` is declared `Promise<BlueprintFile | null>`.
- Its other guard clause (workspace not `ready`) already does the same thing — toast + `return null`.
- Callers handle a `null` result rather than a thrown error.

So this aligns the test with the source (the graceful no-op) instead of changing the source. The test is renamed, un-skipped, and now asserts that the call:

- returns `null`,
- shows the `Branch Required` destructive toast,
- makes no `fetch`.

## Testing

- `pnpm vitest run --project web src/app/sandbox/hooks/useGitHub.test.ts` → **12 passed** (previously 11 + 1 skipped).
- `pnpm test:web` → **49 files / 597 tests passed**, none skipped from this file.
- `pnpm typecheck` → clean (0 errors).

Test-only change; no source/behavior change.
