### PR TITLE
Fix custom model objects with multiple keys being silently skipped

### DIFF
--- a/src/cli/commands/run-config.test.ts
+++ b/src/cli/commands/run-config.test.ts
@@ -242,6 +242,31 @@ describe('run-config validation logic', () => {
         );
       });
 
+      it('should pass through a custom model object with multiple keys (id, url, modelName)', async () => {
+        const customModel = { id: 'my-custom-agent', url: 'http://localhost:3001/v1', modelName: 'gpt-4o' };
+        const result = await resolveModelCollections([customModel], undefined, mockLogger as any);
+
+        expect(result).toEqual([customModel]);
+        // It must NOT be treated as a malformed single-key provider object.
+        expect(mockLogger.warn).not.toHaveBeenCalledWith(
+            expect.stringContaining('Invalid object entry in models array'),
+        );
+      });
+
+      it('should pass custom model objects through alongside strings and collections', async () => {
+        const customModel = { id: 'my-custom-agent', url: 'http://localhost:3001/v1', modelName: 'gpt-4o' };
+        const collectionsRepoPath = '/fake/repo';
+        mockedFs.readFile.mockResolvedValue(JSON.stringify(['google:gemini-1.5-flash-latest']));
+
+        const result = await resolveModelCollections(
+            ['openai:gpt-4o-mini', customModel, 'TEST_COLLECTION'],
+            collectionsRepoPath,
+            mockLogger as any,
+        );
+
+        expect(result).toEqual(['openai:gpt-4o-mini', customModel, 'google:gemini-1.5-flash-latest']);
+      });
+
       it('should deduplicate models from multiple collections and literals', async () => {
         const models = ['openai:gpt-4o-mini', 'COLLECTION_A', 'COLLECTION_B'];
         const collectionsRepoPath = '/fake/repo';

--- a/src/cli/commands/run-config.ts
+++ b/src/cli/commands/run-config.ts
@@ -69,25 +69,28 @@ export async function resolveModelCollections(configModels: any[], collectionsRe
             }
             normalizedConfigModels.push(correctedEntry);
         } else if (typeof modelEntry === 'object' && modelEntry !== null && !Array.isArray(modelEntry)) {
-            const keys = Object.keys(modelEntry);
-            if (keys.length === 1) {
-                const provider = keys[0].trim();
-                const modelNameValue = modelEntry[keys[0]];
-
-                if (typeof modelNameValue === 'string') {
-                    const modelName = modelNameValue.trim();
-                    const corrected = `${provider}:${modelName}`;
-                    logger.warn(`Found model entry as a key-value pair: ${JSON.stringify(modelEntry)}. Interpreting as '${corrected}'. For clarity, please use the string format "provider:model" in your blueprint.`);
-                    normalizedConfigModels.push(corrected);
-                } else {
-                    logger.warn(`Invalid object entry in models array: Key '${provider}' has a non-string value. Skipping: ${JSON.stringify(modelEntry)}.`);
-                }
+            if (modelEntry.id) {
+                // Custom model definition (e.g. { id, url, modelName }). Pass through directly.
+                normalizedConfigModels.push(modelEntry);
             } else {
-                logger.warn(`Invalid object entry in models array: Must have exactly one key (the provider). Found ${keys.length} keys. Skipping: ${JSON.stringify(modelEntry)}.`);
+                // Provider shorthand — expect exactly one key: { provider: modelName }.
+                const keys = Object.keys(modelEntry);
+                if (keys.length === 1) {
+                    const provider = keys[0].trim();
+                    const modelNameValue = modelEntry[keys[0]];
+
+                    if (typeof modelNameValue === 'string') {
+                        const modelName = modelNameValue.trim();
+                        const corrected = `${provider}:${modelName}`;
+                        logger.warn(`Found model entry as a key-value pair: ${JSON.stringify(modelEntry)}. Interpreting as '${corrected}'. For clarity, please use the string format "provider:model" in your blueprint.`);
+                        normalizedConfigModels.push(corrected);
+                    } else {
+                        logger.warn(`Invalid object entry in models array: Key '${provider}' has a non-string value. Skipping: ${JSON.stringify(modelEntry)}.`);
+                    }
+                } else {
+                    logger.warn(`Invalid object entry in models array: expected either an 'id' field (for a custom model definition) or exactly one key (the provider, as { "provider": "modelName" }). Found ${keys.length} keys and no 'id'. Skipping: ${JSON.stringify(modelEntry)}.`);
+                }
             }
-        } else if (typeof modelEntry === 'object' && modelEntry !== null && !Array.isArray(modelEntry) && modelEntry.id) {
-            // This is a custom model definition. Add it directly.
-            normalizedConfigModels.push(modelEntry);
         } else {
              logger.warn(`Invalid entry in models array found: ${JSON.stringify(modelEntry)}. It is not a string or a single key-value object. Skipping this entry.`);
         }


### PR DESCRIPTION
## Summary

Fixes #22. Custom model definitions using object syntax with multiple fields (e.g. `{ id, url, modelName }`) were silently skipped by `resolveModelCollections` and logged a confusing warning.

## Root cause

In `src/cli/commands/run-config.ts`, the object branch checked for a single-key provider object (`{ "provider": "modelName" }`) *before* the custom-model branch. Since a custom model has multiple keys, it failed the single-key check and was skipped with an `Invalid object entry... Must have exactly one key` warning. The `else if (... && modelEntry.id)` branch that was meant to handle custom models was unreachable — the preceding `else if` already matched every non-array object.

## Changes

- Restructured into a single object branch that checks `modelEntry.id` **first** (custom model definition → passed through directly), falling back to the provider-shorthand path. This eliminates the ordering dependency rather than just reordering two sibling branches, so the skip can't silently reappear.
- Clarified the skip warning to mention the `id` option, so the failure is diagnosable instead of cryptic.
- Added two regression tests: the exact `{ id, url, modelName }` case from the issue, and a mixed case (custom model + string literal + collection placeholder).

## Test plan

- `pnpm exec vitest run src/cli/commands/run-config.test.ts` — 22 passed (including the 2 new tests, which return `[]` / drop the model under the old code).
- `tsc --noEmit` clean for the touched files.

## Related issues

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUWffHt992rYTqivjW2V8e)_