### PR TITLE
Add Dependabot for automated dependency and GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Root package.json / pnpm-lock.yaml
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      # Minor and patch bumps arrive as one weekly PR per group.
+      # Major bumps stay as individual PRs so breaking changes get their own review.
+      production-minor-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-minor-patch:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used in .github/workflows/
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` so dependency and GitHub Actions version drift gets an automated update path.

Linear: [PRDENG-12](https://linear.app/collective-intelligenc-project/issue/PRDENG-12/add-dependabot-for-automated-dependency-and-github-actions-updates)
Closes #34

## What's configured

- **`npm` ecosystem** (covers `package.json` + `pnpm-lock.yaml`): weekly on Mondays, minor/patch bumps grouped into two PRs (production and development), majors as individual PRs, open-PR limit of 5, `dependencies` label, `chore(deps)` / `chore(deps-dev)` commit prefixes.
- **`github-actions` ecosystem**: weekly, all action bumps grouped into one PR, open-PR limit of 3, `dependencies` + `ci` labels. The two current workflows only use `run:` steps, so this is dormant until marketplace actions are introduced (e.g. by the CI hardening work).

## Notes

- The `reviewers` key in `dependabot.yml` is deprecated by GitHub; a `CODEOWNERS` file is the supported way to auto-request review on Dependabot PRs if we want that.
- Dependabot *alerts* were already enabled on the repo; automated **security update PRs** are a repo setting (not part of this file) and are being enabled alongside this PR.
- Main currently has 16 open Dependabot alerts (3 critical, 4 high), so expect an initial burst of security PRs once enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)